### PR TITLE
Integrate Philippines Address API

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,7 +60,7 @@ private
 
   def event_params
     params.require(:event).
-      permit(:name, :description, :location, :price, :starts_at, :capacity, :main_image, category_ids: [])
+      permit(:name, :description, :location, :region, :province, :city, :barangay, :price, :starts_at, :capacity, :main_image, category_ids: [])
   end
 end
 

--- a/app/javascript/controllers/select_philippines_address_controller.js
+++ b/app/javascript/controllers/select_philippines_address_controller.js
@@ -1,0 +1,150 @@
+import { Controller } from "@hotwired/stimulus"
+import selectPhilippinesAddress from "selectPhilippinesAddress"
+
+// Connects to data-controller="select-philippines-address"
+export default class extends Controller {
+  connect() {
+    // console.log("Stimulus controller connected");
+  }
+
+  static targets = ["regionInput", "provinceInput", "cityInput", "barangayInput"]
+
+  static values = {
+    regionCode: String,
+    provinceCode: String,
+    cityCode: String,
+    brgyCode: String,
+    regionName: String,
+    provinceName: String,
+    cityName: String,
+    brgyName: String
+  }
+
+  async regionInputTargetConnected(){
+    await this.setRegionOptions()
+    await this.setProvinceOptions()
+    await this.setCityOptions()
+    await this.setBarangayOptions()
+  }
+
+  async regionInputChanged(event){
+    this.regionNameValue = event.target.value
+    await this.setRegionOptions()
+    await this.setProvinceOptions()
+    await this.setCityOptions()
+    await this.setBarangayOptions()
+  }
+
+  async provinceInputChanged(event){
+    this.provinceNameValue = event.target.value
+    await this.setProvinceOptions()
+    await this.setCityOptions()
+    await this.setBarangayOptions()
+  }
+
+  async cityInputChanged(event){
+    this.cityNameValue = event.target.value
+    await this.setCityOptions()
+    await this.setBarangayOptions()
+  }
+
+  async barangayInputChanged(event){
+    this.brgyNameValue = event.target.value
+    await this.setBarangayOptions()
+  }
+
+  async setRegionOptions(){
+    const { regions } = selectPhilippinesAddress;
+
+    this.regionInputTarget.innerHTML = `<option value="">Select Region</option>`
+
+    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+    await sleep(200);
+
+    await regions().then((region) => 
+      region.forEach((r) => {
+        const option = document.createElement("option");
+        option.value = r.region_name;
+        option.innerHTML = r.region_name;
+
+        if (r.region_name == this.regionNameValue) {
+          this.regionCodeValue = r.region_code
+          option.selected = true
+        };
+
+        this.regionInputTarget.appendChild(option);
+      })
+    );
+  }
+
+  async setProvinceOptions(){
+    const { provinces } = selectPhilippinesAddress;
+
+    this.provinceInputTarget.innerHTML = `<option value="">Select Province</option>`
+    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+    await sleep(200);
+
+    await provinces(`${this.regionCodeValue}`).then((province) => {
+      province.forEach((p) => {
+        const option = document.createElement("option");
+        option.value = p.province_name;
+        option.innerHTML = p.province_name;
+
+        if (p.province_name == this.provinceNameValue) {
+          this.provinceCodeValue = p.province_code
+          option.selected = true
+        }
+
+        this.provinceInputTarget.appendChild(option);
+      })
+    });
+  }
+
+  async setCityOptions(){
+    const { cities } = selectPhilippinesAddress;
+
+    this.cityInputTarget.innerHTML = `<option value="">Select City</option>`
+
+    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+    await sleep(200);
+
+    await cities(`${this.provinceCodeValue}`).then((city) => {
+      city.forEach((c) => {
+        const option = document.createElement("option");
+        option.value = c.city_name;
+        option.innerHTML = c.city_name;
+
+        if (c.city_name == this.cityNameValue) {
+          this.cityCodeValue = c.city_code
+          option.selected = true
+        }
+
+        this.cityInputTarget.appendChild(option);
+      })
+    });
+  }
+
+  async setBarangayOptions(){
+    const { barangays } = selectPhilippinesAddress;
+
+    this.barangayInputTarget.innerHTML = `<option value="">Select Barangay</option>`
+
+    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+    await sleep(200);
+
+    await barangays(`${this.cityCodeValue}`).then((brgy) => {
+      brgy.forEach((b) => {
+        const option = document.createElement("option");
+        option.value = b.brgy_name;
+        option.innerHTML = b.brgy_name;
+
+        if (b.brgy_name == this.brgyNameValue) {
+          this.brgyCodeValue = b.brgy_code
+          option.selected = true
+        }
+
+        this.barangayInputTarget.appendChild(option);
+      })
+    });
+  }
+}

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
 
   before_save :set_slug
+  before_save :set_full_location
 
   has_many :registrations, dependent: :destroy
   has_many :likes, dependent: :destroy
@@ -40,6 +41,10 @@ class Event < ApplicationRecord
   end
 
 private
+  def set_full_location
+    self.location = "#{barangay}, #{city}, #{province}, #{region}"
+  end
+
   def acceptable_image
     return unless main_image.attached?
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,12 @@
-<%= form_with(model: event, local: true) do |f| %>
+<%= form_with(model: event, local: true,
+  data: { 
+      controller: "select-philippines-address",
+      select_philippines_address_region_name_value: event.region,
+      select_philippines_address_province_name_value: event.province,
+      select_philippines_address_city_name_value: event.city,
+      select_philippines_address_brgy_name_value: event.barangay,
+  }) do |f| %>
+
   <%= render "shared/errors", object: event %>
 
   <%= f.label :name %>
@@ -7,14 +15,31 @@
   <%= f.label :description %>
   <%= f.text_area :description, rows: 5 %>
 
-  <%= f.label :location %>
-  <%= f.text_field :location %>
+  <div class="my-1">
+    <%= f.label :region, class: "form-label required" %>
+    <%= f.select :region, [], { prompt: "Select Region" }, required: true, data: { "select-philippines-address-target": "regionInput", action: "change->select-philippines-address#regionInputChanged" } %>
+  </div>
+
+  <div class="my-1">
+    <%= f.label :province, class: "form-label required" %>
+    <%= f.select :province, [], { prompt: "Select Province" }, required: true, data: { "select-philippines-address-target": "provinceInput", action: "change->select-philippines-address#provinceInputChanged" } %>
+  </div>
+
+  <div class="my-1">
+    <%= f.label :city, class: "form-label required" %>
+    <%= f.select :city, [], { prompt: "Select City" }, required: true, data: { "select-philippines-address-target": "cityInput", action: "change->select-philippines-address#cityInputChanged" } %>
+  </div>
+
+  <div class="my-1">
+    <%= f.label :barangay, class: "form-label required" %>
+    <%= f.select :barangay, [], { prompt: "Select Barangay" }, required: true, data: { "select-philippines-address-target": "barangayInput", action: "change->select-philippines-address#barangayInputChanged" } %>
+  </div>
 
   <%= f.label :price %>
   <%= f.number_field :price %>
 
   <%= f.label :starts_at %>
-  <%= f.datetime_select :starts_at, {ampm: true}, {class: "datetime"} %>
+  <%= f.datetime_select :starts_at, { ampm: true }, { class: "datetime" } %>
 
   <%= f.label :capacity %>
   <%= f.number_field :capacity %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,4 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "selectPhilippinesAddress", to: "https://cdn.jsdelivr.net/npm/select-philippines-address@1.0.6/+esm", preload: true

--- a/db/migrate/20240929094843_add_address_fields_to_events.rb
+++ b/db/migrate/20240929094843_add_address_fields_to_events.rb
@@ -1,0 +1,8 @@
+class AddAddressFieldsToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :region, :string
+    add_column :events, :province, :string
+    add_column :events, :city, :string
+    add_column :events, :barangay, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_04_235315) do
+ActiveRecord::Schema.define(version: 2024_09_29_094843) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -65,6 +65,10 @@ ActiveRecord::Schema.define(version: 2020_02_04_235315) do
     t.text "description"
     t.integer "capacity", default: 1
     t.string "slug"
+    t.string "region"
+    t.string "province"
+    t.string "city"
+    t.string "barangay"
   end
 
   create_table "likes", force: :cascade do |t|


### PR DESCRIPTION
Ticket: https://github.com/archejk/event-registration-app/issues/2

## Description
### To enhance the event registration form with dynamic address selection using the Philippines Address API

**Reference:**
- https://github.com/isaacdarcilla/select-philippines-address
- https://github.com/wilfredpine/philippine-address-selector

**Changes:**
- [x] Integrate the selectPhilippinesAddress library to fetch address data
- [x] Add migration for `Event` model, fields: `region`, `province`, `city`, `barangay`
- [x] Create dropdowns for selecting regions, provinces, cities, and barangays
- [x] Implement a Stimulus controller for handling asynchronous data loading
- [x] Improve user experience by providing real-time address options